### PR TITLE
Fix the example command line to use the file path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ like this:
 
 ::
 
-    $ gorun.py gorun_settings
+    $ gorun.py gorun_settings.py
 
 Configuration
 -------------


### PR DESCRIPTION
imp.load_source actually takes the filename, not the module name.
